### PR TITLE
Control access to a service using simple denials, attribute-based whi…

### DIFF
--- a/bookinfo/0-bookinfo.yaml
+++ b/bookinfo/0-bookinfo.yaml
@@ -165,7 +165,7 @@ spec:
         ports:
         - containerPort: 9080
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: reviews-v3

--- a/bookinfo/0-bookinfo.yaml
+++ b/bookinfo/0-bookinfo.yaml
@@ -29,7 +29,7 @@ spec:
   selector:
     app: details
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: details-v1
@@ -70,7 +70,7 @@ spec:
   selector:
     app: ratings
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: ratings-v1

--- a/bookinfo/0-bookinfo.yaml
+++ b/bookinfo/0-bookinfo.yaml
@@ -116,7 +116,7 @@ spec:
   selector:
     app: reviews
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: reviews-v1
@@ -140,7 +140,7 @@ spec:
         ports:
         - containerPort: 9080
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: reviews-v2
@@ -212,7 +212,7 @@ spec:
   selector:
     app: productpage
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: productpage-v1

--- a/bookinfo/mixer-rule-deny-label.yaml
+++ b/bookinfo/mixer-rule-deny-label.yaml
@@ -1,0 +1,27 @@
+apiVersion: "config.istio.io/v1alpha2"
+kind: handler
+metadata:
+  name: denyreviewsv3handler
+spec:
+  compiledAdapter: denier
+  params:
+    status:
+      code: 7
+      message: Not allowed
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: instance
+metadata:
+  name: denyreviewsv3request
+spec:
+  compiledTemplate: checknothing
+---
+apiVersion: "config.istio.io/v1alpha2"
+kind: rule
+metadata:
+  name: denyreviewsv3
+spec:
+  match: destination.labels["app"] == "ratings" && source.labels["app"]=="reviews" && source.labels["version"] == "v3"
+  actions:
+  - handler: denyreviewsv3handler
+    instances: [ denyreviewsv3request ]


### PR DESCRIPTION
Added the following examples:
 - Control access to a service using simple denials, attribute-based white or black listing, or IP-based white or black listing
-  Control access to external services that are not part of the mesh

Hands-on exercises at https://github.com/marcredhat/workshop/blob/master/servicemesh/README.adoc

See https://istio.io/docs/tasks/policy-enforcement/denial-and-list/.
Tested on OpenShift 4.3.1 deployed as described at https://github.com/marcredhat/upi/blob/master/ocp43.adoc